### PR TITLE
Increase discoverability of "flip-flop" meaning

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5577,7 +5577,7 @@ Fix by either:
 
 === No Flip-flops [[no-flip-flops]]
 
-Avoid the use of flip-flops.
+Avoid the use of https://en.wikipedia.org/wiki/Flip-flop_(programming)[flip-flop operators].
 
 === No non-`nil` Checks [[no-non-nil-checks]]
 


### PR DESCRIPTION
Some programmers might not be familiar with what a flip-flop is or what it does. Further, it can be tricky (but not impossible) to learn more by searching for "Ruby flip-flop" without being sidetracked into summertime beach footwear options.

Adding the word "operator" helps narrow down internet searches, and providing a link to the relevant Wikipedia page allows readers to easily learn more. At the time of this commit, the Wikipedia page discusses flip-flop operators within Ruby specifically while also giving a good overview of why it is good practice to avoid using them.

When a style guide entry advises against using a particular pattern without explaining what the pattern is, the reader might not be confident that they can successfully follow the guideline. After all, it is difficult to avoid doing something when you don't understand what the "something" is.